### PR TITLE
build aarch64 against latest ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
@@ -31,7 +32,7 @@ jobs:
         uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{ matrix.arch }}
-          distro: bullseye
+          distro: ubuntu_latest
 
           setup: |
             sudo mkdir /app
@@ -39,9 +40,13 @@ jobs:
           dockerRunArgs: |
             --volume /app:/app
 
+          env: |
+            DEBIAN_FRONTEND: noninteractive
+            TZ: Etc/UTC
+
           install: |
-            apt-get update -q -y
-            apt-get install -y git zlib1g-dev libssl-dev gperf cmake g++
+            apt update
+            apt install -y make git zlib1g-dev libssl-dev gperf cmake g++
 
           run: |
             mkdir td/build && cd td/build


### PR DESCRIPTION
Prebuilt on bullseye aarch64 binary requires outdated libssl. 
```
$ ldd libtdjson.so.1.8.14 
	linux-vdso.so.1 (0x0000ffff899c3000)
	libssl.so.1.1 => not found
	libcrypto.so.1.1 => not found
	libz.so.1 => /lib/aarch64-linux-gnu/libz.so.1 (0x0000ffff88360000)
	libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000ffff88140000)
	libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffff880a0000)
	libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000ffff88060000)
	libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000ffff88030000)
	libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffff87e80000)
	/lib/ld-linux-aarch64.so.1 (0x0000ffff89986000)
```
